### PR TITLE
Add API to format volume

### DIFF
--- a/Windows.Storage/Properties/AssemblyInfo.cs
+++ b/Windows.Storage/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.2.0")]
+[assembly: AssemblyNativeVersion("100.0.3.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/Windows.Storage/StorageProvider.cs
+++ b/Windows.Storage/StorageProvider.cs
@@ -3,6 +3,8 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using System.Runtime.CompilerServices;
+
 namespace Windows.Storage
 {
     /// <summary>
@@ -39,6 +41,17 @@ namespace Windows.Storage
         /// The ID can be Local, Network, or OneDrive depending on your provider.
         /// </remarks>
         public string Id => _id;
+
+        /// <summary>
+        /// Formats the specified volume.
+        /// *** NOTE THAT THIS OPERATION IS NOT REVERSIBLE ***.
+        /// </summary>
+        /// <param name="driveNane">The <see cref="KnownFolderId"/> to format.</param>
+        /// <exception cref="System.ArgumentException">Thrown when the <paramref name="driveNane"/> is not a supported <see cref="KnownFolderId"/>.</exception>"
+        /// <exception cref="System.NotSupportedException">Thrown when the target doesn't have support for performing the format operation on the specified folder.</exception>
+        /// <exception cref="System.IO.IOException">Thrown when the operation fails.</exception>"
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public extern void FormatVolume(string driveNane);
 
         //public IAsyncOperation<bool> IsPropertySupportedForPartialFileAsync(String propertyCanonicalName)
         //{ }


### PR DESCRIPTION
## Description
- Add method to class.
- Bump assembly native version.

## Motivation and Context
- Addresses nanoFramework/Home#1229.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
